### PR TITLE
speed up mouse move

### DIFF
--- a/glmap.h
+++ b/glmap.h
@@ -8,15 +8,18 @@
 #include <QOpenGLBuffer>
 #include <QOpenGLVertexArrayObject>
 #include <QMatrix4x4>
+#include <QThread>
 #include "./render.h"
 #include "./world.h"
 #include "./chestview.h"
 #include "./signview.h"
 
 QT_FORWARD_DECLARE_CLASS(QOpenGLShaderProgram)
+QT_FORWARD_DECLARE_CLASS(StatusThread)
 
 class GLMap : public QOpenGLWidget, public QOpenGLFunctions {
   Q_OBJECT
+  friend class StatusThread;
 
  public:
   explicit GLMap(QWidget *parent = 0);
@@ -85,6 +88,8 @@ class GLMap : public QOpenGLWidget, public QOpenGLFunctions {
   bool fullReset;
   QPoint lastMouse;
   bool dragging;
+  StatusThread *runningStatusThread;
+  StatusThread *queuedStatusThread;
 
   ChestView *chestView;
   SignView *signView;
@@ -98,6 +103,23 @@ class GLMap : public QOpenGLWidget, public QOpenGLFunctions {
   int flatW, flatH;
   QOpenGLTexture *flat;
   quint8 *flatData;
+  
+private slots:
+  void startQueuedStatusThread();
+};
+
+
+
+class StatusThread : public QThread {
+  Q_OBJECT
+  const GLMap *map;
+  const QMouseEvent *event;
+  void run();
+public:
+  StatusThread(GLMap *parent, const QMouseEvent *e)
+    : QThread(parent), map(parent), event(e) {}
+signals:
+  void status(const QString &s);
 };
 
 #endif  // GLMAP_H_


### PR DESCRIPTION
improves or even fixes #23

I’m not sure if this is a good approach or even works as intended, but it dramatically increases responsiveness for me. Also it probably leaks all those MouseEvents because I can’t C++.

I call the idea “Sith threads”:

> Two there should be; no more, no less. One to embody power, the other to crave it

One thread is running, the other queued. If the mouse is moved, the queued one is replaced by a new one. Once the running one is finished it will replace itself with the queued one.

This has an advantage over the “don’t run if last run is less than 100ms in the past” approach commonly used to “debounce” javascript, because this way after stopping the mouse, the correct update (the one triggered by the last event) will happen.