### PR TITLE
OSX Compat Fix and GLSL update to deprecated funcs

### DIFF
--- a/Terrafirma.pro
+++ b/Terrafirma.pro
@@ -5,6 +5,7 @@ greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 TARGET = terrafirma
 TEMPLATE = app
 
+macx:CONFIG += c++11
 
 SOURCES += main.cpp\
         mainwindow.cpp \
@@ -86,9 +87,13 @@ RESOURCES += \
 DISTFILES +=
 
 
-desktopfile.path = /usr/share/applications
+!macx:desktopfile.path = /usr/share/applications
+macx:desktopfile.path = ~/Desktop
 desktopfile.files = terrafirma.desktop
-pixmapfile.path = /usr/share/pixmaps
+!macx:pixmapfile.path = /usr/share/pixmaps
+macx:pixmapfile.path = /usr/local/share/pixmaps
 pixmapfile.files = terrafirma.png
-target.path = /usr/bin
-INSTALLS += desktopfile pixmapfile target
+!macx:target.path = /usr/bin
+macx:target.path = ~/Applications
+!macx:INSTALLS += desktopfile pixmapfile target
+macx:INSTALLS += pixmapfile target

--- a/glmap.cpp
+++ b/glmap.cpp
@@ -11,6 +11,7 @@
 #include <QMouseEvent>
 #include <QSettings>
 #include <QSurfaceFormat>
+#include <cmath>
 #include "./uvrules.h"
 
 /*

--- a/res/shaders/flat_fs.glsl
+++ b/res/shaders/flat_fs.glsl
@@ -2,13 +2,13 @@
 
 in vec2 uv;
 
-uniform sampler2D texture;
+uniform sampler2D txtr;
 uniform bool hiliting;
 
 out vec4 color;
 
 void main() {
-  vec4 c = texture2D(texture, uv);
+  vec4 c = texture(txtr, uv);
   if (hiliting && c.rgb != vec3(1.0, 0.8, 1.0))
     c.rgb *= vec3(0.3, 0.3, 0.3);
   color = c;

--- a/res/shaders/tiles_fs.glsl
+++ b/res/shaders/tiles_fs.glsl
@@ -4,13 +4,13 @@ in vec2 uv;
 in float hilite;
 in float paint;
 
-uniform sampler2D texture;
+uniform sampler2D txtr;
 uniform bool hiliting;
 
 out vec4 color;
 
 void main() {
-  vec4 c = texture2D(texture, uv);
+  vec4 c = texture(txtr, uv);
 
   int paintgroup = int(paint);
   // only paint grass

--- a/res/shaders/water_fs.glsl
+++ b/res/shaders/water_fs.glsl
@@ -3,13 +3,13 @@
 in vec2 uv;
 in float alpha;
 
-uniform sampler2D texture;
+uniform sampler2D txtr;
 uniform bool hiliting;
 
 out vec4 color;
 
 void main() {
-  vec4 c = texture2D(texture, uv);
+  vec4 c = texture(txtr, uv);
   c.a = alpha;
   if (c.a < 0.1)
     discard;


### PR DESCRIPTION
Brought calls to deprecated GLSL function names into compliance with newer function names. Renamed conflicting variables.
Added platform specific tags for OSX to enable build and clean up install