### PR TITLE
Portable fix for OS X texture issues

### DIFF
--- a/settingsdialog.cpp
+++ b/settingsdialog.cpp
@@ -46,7 +46,12 @@ SettingsDialog::SettingsDialog(QWidget *parent) : QDialog(parent),
 
   defaultTextures = "";
   if (terrariaDir.exists())
+#if 0
     defaultTextures = terrariaDir.absoluteFilePath("Content/Images");
+#else
+    // For MacOS
+    defaultTextures = terrariaDir.absoluteFilePath("Terraria.app/Contents/MacOS/Content/Images");
+#endif
 
   QDir worldDir = QDir(
         QStandardPaths::standardLocations(QStandardPaths::DocumentsLocation)

--- a/settingsdialog.cpp
+++ b/settingsdialog.cpp
@@ -46,11 +46,12 @@ SettingsDialog::SettingsDialog(QWidget *parent) : QDialog(parent),
 
   defaultTextures = "";
   if (terrariaDir.exists())
-#if 0
-    defaultTextures = terrariaDir.absoluteFilePath("Content/Images");
-#else
-    // For MacOS
+#ifdef Q_OS_DARWIN
+    // Darwin-based OS such as OS X and iOS, including any open source
+    // version(s) of Darwin.
     defaultTextures = terrariaDir.absoluteFilePath("Terraria.app/Contents/MacOS/Content/Images");
+#else
+    defaultTextures = terrariaDir.absoluteFilePath("Content/Images");
 #endif
 
   QDir worldDir = QDir(


### PR DESCRIPTION
The texture files are located in a different location for Apple OS X. 

Thanks to @biouxtai for the assistance! 

I tested this fix on both OS X (El Capitan 10.11.3) and Ubuntu Linux 14.04.4 LTS, and it seems to work fine. 