### PR TITLE
Update README.md with newer macOS instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Building on macOS/OSX:
 
 NEW 2019 Updated Instructions:
 
-Use the Homebrew package manager and install Qt:
+Use the [Homebrew package manager](https://brew.sh) and install Qt:
 
 ```console
 $ brew install qt5
@@ -73,7 +73,7 @@ $ brew install qt5
 Then use qt5 to run qmake and compile:
 
 ```console
-(Note--path may be slightly different, if qt has been updated)
+# (Note--path may be slightly different, if qt has been updated)
 $ /usr/local/Cellar/qt5/5.12.0/bin/qmake
 $ make
 $ open terrafirma.app

--- a/README.md
+++ b/README.md
@@ -59,8 +59,27 @@ $ cd ..
 $ pbuilder-dist vivid build *.dsc
 ```
 
-Building on OSX:
+Building on macOS/OSX:
 ----------------
+
+NEW 2019 Updated Instructions:
+
+Use the Homebrew package manager and install Qt:
+
+```console
+$ brew install qt5
+```
+
+Then use qt5 to run qmake and compile:
+
+```console
+(Note--path may be slightly different, if qt has been updated)
+$ /usr/local/Cellar/qt5/5.12.0/bin/qmake
+$ make
+$ open terrafirma.app
+```
+
+OLD Instructions:
 
 Make a static compile of Qt 5.5:
 
@@ -82,3 +101,5 @@ $ cd TerraFirma
 $ ~/qt5/qtbase/bin/qmake
 $ make
 ```
+
+


### PR DESCRIPTION
I don't think it's necessary to build Qt5 from source. It seems to work
fine if you just install the version from Homebrew. YMMV.