### PR TITLE
Quick hack for Terraria 1.4.1.1

### DIFF
--- a/settingsdialog.cpp
+++ b/settingsdialog.cpp
@@ -41,8 +41,8 @@ SettingsDialog::SettingsDialog(QWidget *parent) : QDialog(parent),
 #ifdef Q_OS_DARWIN
     // Darwin-based OS such as OS X and iOS, including any open source
     // version(s) of Darwin.
-    defaultTextures = terrariaDir.absoluteFilePath("Terraria.app/Contents/MacOS/Content/Images");
-    defaultExes = terrariaDir.absoluteFilePath("Terraria.app/Contents/MacOS/Terraria.exe");
+    defaultTextures = terrariaDir.absoluteFilePath("Terraria.app/Contents/Resources/Content/Images");
+    defaultExes = terrariaDir.absoluteFilePath("Terraria.app/Contents/MacOS/Terraria.bin.osx");
 #else
     defaultTextures = terrariaDir.absoluteFilePath("Content/Images");
     defaultExes = terrariaDir.absoluteFilePath("Terraria.exe");

--- a/world.h
+++ b/world.h
@@ -35,7 +35,7 @@ class Tile {
 
 class World : public QObject, public QRunnable {
   static const int MinimumVersion = 88;
-  static const int HighestVersion = 230;
+  static const int HighestVersion = 233;
 
 
   Q_OBJECT


### PR DESCRIPTION
This is a quick hack for macOS and Terraria 1.4.1.1. It addresses Issue #111 , 
although it is possibly not a complete fix. 

The biggest change is that the world version number has increased from
230 to 233 in `world.h`, and changing this value lets the game load.

Also, it appears that some of the files have moved, at least on macOS,
so I tweaked the default locations in the `settingsdialog.cpp` file. You can
manually override the settings, but IMHO that should not be necessary
for an unmodified Steam install.

TODO:
- Make sure any new textures are supported
- Possibly add a check in settingsdialog.cpp to look for files in both
  the new and old places, and if it only exists in one place, use that.
- See what changes, if any, are needed for Windows and Linux