### PR TITLE
Fix autodetect paths on Linux

### DIFF
--- a/settingsdialog.cpp
+++ b/settingsdialog.cpp
@@ -31,8 +31,13 @@ SettingsDialog::SettingsDialog(QWidget *parent) : QDialog(parent),
   }
   QString installDir = steam["software/valve/steam/apps/105600/installdir"];
   QDir terrariaDir = QDir(installDir);
-  if (installDir.isEmpty() || !terrariaDir.exists())
+  if (installDir.isEmpty() || !terrariaDir.exists()) {
     terrariaDir.setPath(steamDir.absoluteFilePath("SteamApps/common/Terraria"));
+
+    // On Linux the SteamApps directory is lower case
+    if (!terrariaDir.exists())
+      terrariaDir.setPath(steamDir.absoluteFilePath("steamapps/common/Terraria"));
+  }
 
   defaultExes = "";
   defaultTextures = "";


### PR DESCRIPTION
I'm using the native Steam client on Manjaro KDE. My `config.vdf` doesn't contain the `apps` section (not sure if this is specific to Linux or something that has changed in Steam).

Then the fallback method of detecting the exe and texture paths also fails because the `SteamApps` directory is named `steamapps`. This PR just adds a check for that.
